### PR TITLE
Add slice write support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 _obj
 _test
 
+# intellij idea files
+.idea
+
 # Architecture specific extensions/prefixes
 *.[568vq]
 [568vq].out

--- a/MCP23S17/MCP23S17.go
+++ b/MCP23S17/MCP23S17.go
@@ -2,6 +2,7 @@ package MCP23S17
 
 import (
 	"fmt"
+
 	"github.com/luismesas/goPi/spi"
 )
 
@@ -62,7 +63,7 @@ type MCP23S17 struct {
 
 func NewMCP23S17(hardwareAddress uint8, bus int, chip_select int) *MCP23S17 {
 	mcp := new(MCP23S17)
-	mcp.Device = spi.NewSPIDevice(bus, chip_select)
+	mcp.Device = spi.NewSPIDevice(bus, chip_select, spi.SPI_DELAY)
 	mcp.HardwareAddress = hardwareAddress
 
 	mcp.IODIRa = NewMCP23S17Register(IODIRA, mcp)
@@ -141,7 +142,7 @@ func (mcp *MCP23S17) getSPIControlByte(read_write_cmd uint8) byte {
 // Returns the value of the address specified.
 func (mcp *MCP23S17) Read(address byte) byte {
 	ctrl_byte := mcp.getSPIControlByte(READ_CMD)
-	data, err := mcp.Device.Send([3]byte{ctrl_byte, address, 0})
+	data, err := mcp.Device.Send([]byte{ctrl_byte, address, 0})
 	if err != nil {
 		panic(fmt.Sprintf("Error reading from MCP23S17: %s\n", err))
 		return 0x00
@@ -155,7 +156,7 @@ func (mcp *MCP23S17) Read(address byte) byte {
 // Writes data to the address specified.
 func (mcp *MCP23S17) Write(data byte, address byte) {
 	ctrl_byte := mcp.getSPIControlByte(WRITE_CMD)
-	_, err := mcp.Device.Send([3]byte{ctrl_byte, address, data})
+	_, err := mcp.Device.Send([]byte{ctrl_byte, address, data})
 	if err != nil {
 		panic(fmt.Sprintf("Error writing on MCP23S17: %s\n", err))
 	}

--- a/examples/blink_MCP23S17/blink_MCP23S17.go
+++ b/examples/blink_MCP23S17/blink_MCP23S17.go
@@ -1,10 +1,11 @@
 package main
 
 import (
-	"github.com/luismesas/goPi/MCP23S17"
-	"github.com/luismesas/goPi/spi"
 	"log"
 	"time"
+
+	"github.com/luismesas/goPi/MCP23S17"
+	"github.com/luismesas/goPi/spi"
 )
 
 func main() {

--- a/examples/blink_piface/blink_piface.go
+++ b/examples/blink_piface/blink_piface.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/luismesas/goPi/piface"
 	"github.com/luismesas/goPi/spi"
-	"time"
 )
 
 func main() {

--- a/piface/piface.go
+++ b/piface/piface.go
@@ -1,22 +1,21 @@
-/* 
-Package piface is for interfacing with a PiFace Digital IO board. 
+/*
+Package piface is for interfacing with a PiFace Digital IO board.
 
  - More Info at http://www.piface.org.uk/products/piface_digital/
  - Guides at http://prod.www.piface.org.uk/guides/
  - goPi blink example at  https://github.com/luismesas/goPi/blob/master/examples/blink_piface/blink_piface.go
 
 Its possible to connect up to four PiFace boards to a Raspberry Pi, however some jumper
-settings are required to set the hardware address. 
+settings are required to set the hardware address.
 
  - See http://prod.www.piface.org.uk/guides/howto/PiFace_Digital_Jumper_Settings/
 
 */
 package piface
 
-
-
 import (
 	"fmt"
+
 	"github.com/luismesas/goPi/MCP23S17"
 )
 

--- a/rpi.go
+++ b/rpi.go
@@ -1,11 +1,10 @@
-
 // Package rpi is a library for interfacing with Raspberry Pi IO
 package rpi
 
-// This is the wrong url here ??? 
+// This is the wrong url here ???
 import (
 	_ "github.com/luismesas/goPi/MCP23S17"
 	_ "github.com/luismesas/goPi/ioctl"
-	_ "github.com/luismesas/goPi/spi"
 	_ "github.com/luismesas/goPi/piface"
+	_ "github.com/luismesas/goPi/spi"
 )

--- a/spi/spi.go
+++ b/spi/spi.go
@@ -1,8 +1,9 @@
 package spi
 
 import (
-	"github.com/luismesas/goPi/ioctl"
 	"unsafe"
+
+	"github.com/luismesas/goPi/ioctl"
 )
 
 const SPI_IOC_MAGIC = 107


### PR DESCRIPTION
Hi luismesas!
I know this is a quite old project of yours, but since its one of the only implementations of a golang only spi driver, I used your code. But I needed the spi to write a more generic slice of byte and have a way to use the delay feature of the kernel. The changes made should not affect your usage. I also ran goformat on the code.

* Add slice write support
* Add delay setting
* goimports (go fmt)

Greetings - buttairfly (Till Max Schwikal)